### PR TITLE
Add Terraform Configuration for EKS Cluster with Autoscaler

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -10,7 +10,17 @@ The infrastructure includes:
 - An EKS cluster deployed in the private subnets
 - A managed node group with autoscaling capabilities
 - Cluster Autoscaler for automatically adjusting the size of the Kubernetes cluster based on resource demands
+- IAM Roles for Service Accounts (IRSA) for secure pod-level access to AWS resources
 - Necessary IAM roles and policies for the EKS cluster and Cluster Autoscaler
+
+## IAM Roles for Service Accounts (IRSA)
+
+This configuration uses IRSA to provide fine-grained access control for the Cluster Autoscaler. IRSA allows Kubernetes service accounts to assume IAM roles directly, which provides the following benefits:
+
+- Improved security by using temporary credentials
+- Fine-grained access control at the pod level
+- Reduced need for node instance profiles with broad permissions
+- Simplified management of AWS permissions for Kubernetes workloads
 
 ## Prerequisites
 
@@ -55,6 +65,12 @@ kubectl get nodes
 
 ```bash
 kubectl get pods -n kube-system | grep cluster-autoscaler
+```
+
+7. Verify the IRSA configuration:
+
+```bash
+kubectl describe serviceaccount cluster-autoscaler -n kube-system
 ```
 
 ## Customization

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,78 @@
+# EKS Cluster with Terraform
+
+This directory contains Terraform configuration for deploying an Amazon EKS (Elastic Kubernetes Service) cluster across 3 subnets with the Kubernetes Cluster Autoscaler.
+
+## Architecture
+
+The infrastructure includes:
+
+- A VPC with 3 private subnets and 3 public subnets across different availability zones
+- An EKS cluster deployed in the private subnets
+- A managed node group with autoscaling capabilities
+- Cluster Autoscaler for automatically adjusting the size of the Kubernetes cluster based on resource demands
+- Necessary IAM roles and policies for the EKS cluster and Cluster Autoscaler
+
+## Prerequisites
+
+- AWS CLI configured with appropriate credentials
+- Terraform >= 1.0.0
+- kubectl
+- helm
+
+## Usage
+
+1. Initialize Terraform:
+
+```bash
+terraform init
+```
+
+2. Review the execution plan:
+
+```bash
+terraform plan
+```
+
+3. Apply the configuration:
+
+```bash
+terraform apply
+```
+
+4. Configure kubectl to use the new cluster:
+
+```bash
+aws eks update-kubeconfig --region $(terraform output -raw aws_region) --name $(terraform output -raw cluster_name)
+```
+
+5. Verify the cluster is working:
+
+```bash
+kubectl get nodes
+```
+
+6. Verify the Cluster Autoscaler is running:
+
+```bash
+kubectl get pods -n kube-system | grep cluster-autoscaler
+```
+
+## Customization
+
+You can customize the deployment by modifying the variables in `variables.tf`. Key variables include:
+
+- `aws_region`: AWS region to deploy resources
+- `cluster_name`: Name of the EKS cluster
+- `vpc_cidr`: CIDR block for the VPC
+- `subnet_cidrs`: CIDR blocks for the subnets
+- `node_instance_type`: EC2 instance type for the node group
+- `node_min_size`: Minimum number of nodes in the node group
+- `node_max_size`: Maximum number of nodes in the node group
+
+## Cleanup
+
+To destroy all resources created by Terraform:
+
+```bash
+terraform destroy
+```

--- a/terraform/autoscaler.tf
+++ b/terraform/autoscaler.tf
@@ -1,5 +1,25 @@
 # Cluster autoscaler configuration
 
+# Create a Kubernetes service account for the cluster autoscaler
+resource "kubernetes_service_account" "cluster_autoscaler" {
+  metadata {
+    name      = "cluster-autoscaler"
+    namespace = "kube-system"
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.cluster_autoscaler.arn
+    }
+    labels = {
+      "k8s-addon" = "cluster-autoscaler.addons.k8s.io"
+      "k8s-app"   = "cluster-autoscaler"
+    }
+  }
+
+  depends_on = [
+    module.eks
+  ]
+}
+
+# Deploy the cluster autoscaler using Helm
 resource "helm_release" "cluster_autoscaler" {
   name       = "cluster-autoscaler"
   repository = "https://kubernetes.github.io/autoscaler"
@@ -18,12 +38,18 @@ resource "helm_release" "cluster_autoscaler" {
   }
 
   set {
-    name  = "rbac.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
-    value = module.eks.eks_managed_node_groups.main.iam_role_arn
+    name  = "rbac.serviceAccount.create"
+    value = "false"
   }
 
-  # Only deploy after the EKS cluster is ready
+  set {
+    name  = "rbac.serviceAccount.name"
+    value = kubernetes_service_account.cluster_autoscaler.metadata[0].name
+  }
+
+  # Only deploy after the EKS cluster and service account are ready
   depends_on = [
-    module.eks
+    module.eks,
+    kubernetes_service_account.cluster_autoscaler
   ]
 }

--- a/terraform/autoscaler.tf
+++ b/terraform/autoscaler.tf
@@ -1,0 +1,29 @@
+# Cluster autoscaler configuration
+
+resource "helm_release" "cluster_autoscaler" {
+  name       = "cluster-autoscaler"
+  repository = "https://kubernetes.github.io/autoscaler"
+  chart      = "cluster-autoscaler"
+  namespace  = "kube-system"
+  version    = "9.29.0"
+
+  set {
+    name  = "autoDiscovery.clusterName"
+    value = module.eks.cluster_name
+  }
+
+  set {
+    name  = "awsRegion"
+    value = var.aws_region
+  }
+
+  set {
+    name  = "rbac.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+    value = module.eks.eks_managed_node_groups.main.iam_role_arn
+  }
+
+  # Only deploy after the EKS cluster is ready
+  depends_on = [
+    module.eks
+  ]
+}

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -16,6 +16,9 @@ module "eks" {
   # Enable EKS Cluster CloudWatch Logging
   cluster_enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 
+  # Enable IRSA (IAM Roles for Service Accounts)
+  enable_irsa = true
+
   # Add required tags for the cluster autoscaler
   tags = merge(
     var.tags,

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -1,0 +1,57 @@
+# EKS cluster configuration
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 19.0"
+
+  cluster_name    = var.cluster_name
+  cluster_version = "1.27"
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  cluster_endpoint_private_access = true
+  cluster_endpoint_public_access  = true
+
+  # Enable EKS Cluster CloudWatch Logging
+  cluster_enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+
+  # Add required tags for the cluster autoscaler
+  tags = merge(
+    var.tags,
+    {
+      "k8s.io/cluster-autoscaler/${var.cluster_name}" = "owned"
+      "k8s.io/cluster-autoscaler/enabled"             = "true"
+    }
+  )
+
+  # EKS Managed Node Group(s)
+  eks_managed_node_group_defaults = {
+    ami_type       = "AL2_x86_64"
+    instance_types = [var.node_instance_type]
+
+    attach_cluster_primary_security_group = true
+  }
+
+  eks_managed_node_groups = {
+    main = {
+      name = var.node_group_name
+
+      min_size     = var.node_min_size
+      max_size     = var.node_max_size
+      desired_size = var.node_desired_capacity
+
+      # Add required tags for the cluster autoscaler
+      tags = merge(
+        var.tags,
+        {
+          "k8s.io/cluster-autoscaler/${var.cluster_name}" = "owned"
+          "k8s.io/cluster-autoscaler/enabled"             = "true"
+        }
+      )
+    }
+  }
+
+  # aws-auth configmap
+  manage_aws_auth_configmap = true
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,32 @@
+# IAM roles and policies for EKS cluster
+
+# IAM policy for the cluster autoscaler
+resource "aws_iam_policy" "cluster_autoscaler" {
+  name        = "${var.cluster_name}-cluster-autoscaler"
+  description = "EKS cluster autoscaler policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "autoscaling:DescribeAutoScalingGroups",
+          "autoscaling:DescribeAutoScalingInstances",
+          "autoscaling:DescribeLaunchConfigurations",
+          "autoscaling:DescribeTags",
+          "autoscaling:SetDesiredCapacity",
+          "autoscaling:TerminateInstanceInAutoScalingGroup",
+          "ec2:DescribeLaunchTemplateVersions"
+        ]
+        Resource = "*"
+        Effect   = "Allow"
+      },
+    ]
+  })
+}
+
+# Attach the cluster autoscaler policy to the EKS node group role
+resource "aws_iam_role_policy_attachment" "cluster_autoscaler" {
+  policy_arn = aws_iam_policy.cluster_autoscaler.arn
+  role       = module.eks.eks_managed_node_groups.main.iam_role_name
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,5 +1,16 @@
 # IAM roles and policies for EKS cluster
 
+# Create an IAM OIDC provider for the EKS cluster
+data "tls_certificate" "eks" {
+  url = module.eks.cluster_oidc_issuer_url
+}
+
+resource "aws_iam_openid_connect_provider" "eks" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.eks.certificates[0].sha1_fingerprint]
+  url             = module.eks.cluster_oidc_issuer_url
+}
+
 # IAM policy for the cluster autoscaler
 resource "aws_iam_policy" "cluster_autoscaler" {
   name        = "${var.cluster_name}-cluster-autoscaler"
@@ -25,8 +36,32 @@ resource "aws_iam_policy" "cluster_autoscaler" {
   })
 }
 
-# Attach the cluster autoscaler policy to the EKS node group role
+# Create IAM role for the cluster autoscaler service account (IRSA)
+data "aws_iam_policy_document" "cluster_autoscaler_assume_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_iam_openid_connect_provider.eks.url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:kube-system:cluster-autoscaler"]
+    }
+
+    principals {
+      identifiers = [aws_iam_openid_connect_provider.eks.arn]
+      type        = "Federated"
+    }
+  }
+}
+
+resource "aws_iam_role" "cluster_autoscaler" {
+  name               = "${var.cluster_name}-cluster-autoscaler"
+  assume_role_policy = data.aws_iam_policy_document.cluster_autoscaler_assume_role.json
+}
+
+# Attach the cluster autoscaler policy to the IAM role
 resource "aws_iam_role_policy_attachment" "cluster_autoscaler" {
   policy_arn = aws_iam_policy.cluster_autoscaler.arn
-  role       = module.eks.eks_managed_node_groups.main.iam_role_name
+  role       = aws_iam_role.cluster_autoscaler.name
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,50 @@
+# Main Terraform configuration for EKS cluster
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_availability_zones" "available" {}
+
+# Configure the Kubernetes provider
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+    command     = "aws"
+  }
+}
+
+# Configure the Helm provider
+provider "helm" {
+  kubernetes {
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+      command     = "aws"
+    }
+  }
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.47.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.10.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.4.1"
+    }
+  }
+  
+  required_version = ">= 1.0.0"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -44,6 +44,10 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.4.1"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.0.0"
+    }
   }
   
   required_version = ">= 1.0.0"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,41 @@
+# Outputs for EKS cluster
+
+output "cluster_id" {
+  description = "EKS cluster ID"
+  value       = module.eks.cluster_id
+}
+
+output "cluster_endpoint" {
+  description = "Endpoint for EKS control plane"
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_security_group_id" {
+  description = "Security group ID attached to the EKS cluster"
+  value       = module.eks.cluster_security_group_id
+}
+
+output "cluster_name" {
+  description = "Kubernetes Cluster Name"
+  value       = module.eks.cluster_name
+}
+
+output "vpc_id" {
+  description = "VPC ID"
+  value       = module.vpc.vpc_id
+}
+
+output "public_subnets" {
+  description = "List of public subnet IDs"
+  value       = module.vpc.public_subnets
+}
+
+output "private_subnets" {
+  description = "List of private subnet IDs"
+  value       = module.vpc.private_subnets
+}
+
+output "kubectl_config_command" {
+  description = "Command to configure kubectl"
+  value       = "aws eks update-kubeconfig --region ${var.aws_region} --name ${module.eks.cluster_name}"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,71 @@
+# Variables for EKS cluster configuration
+
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "cluster_name" {
+  description = "Name of the EKS cluster"
+  type        = string
+  default     = "eks-demo-cluster"
+}
+
+variable "vpc_name" {
+  description = "Name of the VPC"
+  type        = string
+  default     = "eks-vpc"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "subnet_cidrs" {
+  description = "CIDR blocks for the subnets (3 subnets)"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+}
+
+variable "node_group_name" {
+  description = "Name of the EKS node group"
+  type        = string
+  default     = "eks-node-group"
+}
+
+variable "node_instance_type" {
+  description = "EC2 instance type for the node group"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "node_desired_capacity" {
+  description = "Desired number of nodes in the node group"
+  type        = number
+  default     = 3
+}
+
+variable "node_min_size" {
+  description = "Minimum number of nodes in the node group"
+  type        = number
+  default     = 1
+}
+
+variable "node_max_size" {
+  description = "Maximum number of nodes in the node group"
+  type        = number
+  default     = 5
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {
+    Environment = "dev"
+    Terraform   = "true"
+    Project     = "eks-demo"
+  }
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,30 @@
+# VPC configuration for EKS cluster
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  name = var.vpc_name
+  cidr = var.vpc_cidr
+
+  azs             = slice(data.aws_availability_zones.available.names, 0, 3)
+  private_subnets = var.subnet_cidrs
+  public_subnets  = [for i, cidr in var.subnet_cidrs : cidrsubnet(var.vpc_cidr, 8, i + 100)]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  # Tags required for EKS
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                    = "1"
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"           = "1"
+  }
+
+  tags = var.tags
+}


### PR DESCRIPTION
This PR adds Terraform configuration for deploying an Amazon EKS (Elastic Kubernetes Service) cluster across 3 subnets with the Kubernetes Cluster Autoscaler.

## Features

- VPC with 3 private subnets and 3 public subnets across different availability zones
- EKS cluster deployed in the private subnets
- Managed node group with autoscaling capabilities
- Cluster Autoscaler for automatically adjusting the size of the Kubernetes cluster based on resource demands
- Necessary IAM roles and policies for the EKS cluster and Cluster Autoscaler
- Comprehensive documentation in README.md

## Implementation

The implementation includes the following Terraform files:

1. `main.tf` - Main Terraform configuration with provider setup
2. `variables.tf` - Variable definitions for customizing the deployment
3. `outputs.tf` - Output definitions for important resource information
4. `vpc.tf` - VPC and subnet configuration using the AWS VPC module
5. `eks.tf` - EKS cluster configuration using the AWS EKS module
6. `iam.tf` - IAM roles and policies for EKS and Cluster Autoscaler
7. `autoscaler.tf` - Cluster Autoscaler deployment using Helm
8. `README.md` - Documentation for the Terraform configuration

## Usage

Detailed usage instructions are provided in the README.md file, including:

- Prerequisites
- Deployment steps
- Verification steps
- Customization options
- Cleanup instructions